### PR TITLE
Add a check for br_netfilter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         run: |
           sudo git clone --depth 1 --branch v1.8.0 https://github.com/bats-core/bats-core.git /opt/bats
           sudo /opt/bats/install.sh /usr/local
+
+      - name: Enable br_netfilter kernel module
+        run: sudo modprobe br_netfilter
           
       - name: Run test suite
         run: bats test/test.bats

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ TrafficJam allows you to safely and easily connect all of your backend container
 ## How TrafficJam Works
 TrafficJam works by adding some firewall (`iptables`) rules to the docker network you specify. First, it blocks all traffic on the network. Then it adds a rule that only allows traffic to/from the container(s) you specify in the whitelist. It continually monitors the docker network to make sure the rules stay up to date as you add or remove containers.
 
+## Dependencies
+trafficjam requires the `br_netfilter` kernel module to filter traffic on docker networks. If the module is not loaded, trafficjam will attempt to load it automatically. In some cases, it cannot be loaded automatically (e.g. rootless docker), and must be loaded manually, such as by adding "br_netfilter" to /etc/modules.
+
 ## Setup Examples
 
 ### Vanilla Docker

--- a/trafficjam-functions.sh
+++ b/trafficjam-functions.sh
@@ -44,6 +44,16 @@ function detect_iptables_version() {
 	fi
 }
 
+function detect_br_netfilter() {
+	if lsmod | grep -q br_netfilter; then
+		log_debug "br_netfilter already loaded"
+		return 0
+	fi
+
+	log_error "br_netfilter is required by trafficjam and could not be detected. (See https://github.com/kaysond/trafficjam/#dependencies)"
+
+}
+
 function clear_rules() {
 	if [[ -z "${NETWORK_DRIVER:-}" ]]; then
 		get_network_driver || NETWORK_DRIVER=local

--- a/trafficjam.sh
+++ b/trafficjam.sh
@@ -54,6 +54,8 @@ if [[ "${1:-}" == "--clear" ]]; then
 	clear_rules
 fi
 
+detect_br_netfilter || exit 1
+
 if [[ -n "$SWARM_DAEMON" ]]; then
 	remove_service
 


### PR DESCRIPTION
In recent versions of docker (around 27), many changes were made to the logic for automatically loading br_netfilter. It seems the latest logic is only to enable it when the Inter-Container Communication (ICC) or userland-proxy are disabled (neither of which are the default).

See:
* https://github.com/moby/moby/blob/28.x/libnetwork/drivers/bridge/bridge_linux.go
* https://github.com/moby/moby/commit/0548fe251c8d5df99347cba52dd5cffbcd9d913d
* https://github.com/moby/moby/commit/264c15bfc427d1321c5b302e48e16d113b06ef92
* https://github.com/moby/moby/commit/5c499fc4b249708619b4225de00c50c861bcfc08
* https://github.com/moby/moby/issues/48948