### PR TITLE
feat: Move Trafficjam rules to own chain keyed by INSTANCE_ID

### DIFF
--- a/trafficjam-functions.sh
+++ b/trafficjam-functions.sh
@@ -71,14 +71,14 @@ function clear_rules() {
 	fi
 
 	# Remove jump rules if they exist
-	iptables_tj --table filter --delete "$PARENT_CHAIN" --jump "$TJ_CHAIN" 2>/dev/null || true
-	iptables_tj --table filter --delete INPUT --jump "$TJ_INPUT_CHAIN" 2>/dev/null || true
+	iptables_tj --table filter --delete "$PARENT_CHAIN" --jump "$TJ_CHAIN" 2> /dev/null || true
+	iptables_tj --table filter --delete INPUT --jump "$TJ_INPUT_CHAIN" 2> /dev/null || true
 
 	# Flush and delete instance chains if they exist
-	iptables_tj --table filter --flush "$TJ_CHAIN" 2>/dev/null || true
-	iptables_tj --table filter --delete-chain "$TJ_CHAIN" 2>/dev/null || true
-	iptables_tj --table filter --flush "$TJ_INPUT_CHAIN" 2>/dev/null || true
-	iptables_tj --table filter --delete-chain "$TJ_INPUT_CHAIN" 2>/dev/null || true
+	iptables_tj --table filter --flush "$TJ_CHAIN" 2> /dev/null || true
+	iptables_tj --table filter --delete-chain "$TJ_CHAIN" 2> /dev/null || true
+	iptables_tj --table filter --flush "$TJ_INPUT_CHAIN" 2> /dev/null || true
+	iptables_tj --table filter --delete-chain "$TJ_INPUT_CHAIN" 2> /dev/null || true
 
 	log "Cleared rules for instance $INSTANCE_ID"
 	exit 0

--- a/trafficjam.sh
+++ b/trafficjam.sh
@@ -42,8 +42,8 @@ fi
 
 # Check if "TJ_INPUT_$INSTANCE_ID" is over 28 characters long (max chain name length)
 if [[ ${#INSTANCE_ID} -gt 16 ]]; then
-		echo "Chain name would be too long, consider shortening INSTANCE_ID" >&2
-		exit 1
+	echo "Chain name would be too long, consider shortening INSTANCE_ID" >&2
+	exit 1
 fi
 
 . trafficjam-functions.sh
@@ -101,7 +101,7 @@ else
 
 		DATE=$(date "+%Y-%m-%d %H:%M:%S")
 
-		if [[
+		if [[ 
 			"$SUBNET" != "$OLD_SUBNET" ||
 			"$WHITELIST_IPS" != "$OLD_WHITELIST_IPS" ||
 			"$LOCAL_LOAD_BALANCER_IP" != "$OLD_LOCAL_LOAD_BALANCER_IP" ]] \
@@ -113,13 +113,13 @@ else
 			fi
 
 			add_chain || continue
-			iptables_tj --table filter --flush "TJ_$INSTANCE_ID" 2>/dev/null || true
+			iptables_tj --table filter --flush "TJ_$INSTANCE_ID" 2> /dev/null || true
 
 			block_subnet_traffic || continue
 
 			if [[ -z "$ALLOW_HOST_TRAFFIC" ]]; then
 				add_input_chain || continue
-				iptables_tj --table filter --flush "TJ_INPUT_$INSTANCE_ID" 2>/dev/null || true
+				iptables_tj --table filter --flush "TJ_INPUT_$INSTANCE_ID" 2> /dev/null || true
 				block_host_traffic || continue
 			fi
 


### PR DESCRIPTION
...so they don't interfere with each other.

Disclaimer: I asked Gemini what a good solution would be and it suggested it. It changed the functions, which I reviewed and then tested, then bugfixed (as you expect, I guess). This should work now, though I'm not familiar with the codebase or iptables very much.

It would (potentially) also be good to add code to replace "old-style" rules before applying the new rules